### PR TITLE
Check for ngx.socket.tcp availability on .new()

### DIFF
--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -125,7 +125,7 @@ function _M.new(self)
     math.randomseed(ngx and ngx.time() or os.time())
 
     local tcp
-    if ngx then
+    if ngx and ngx.socket and ngx.socket.tcp then
         -- openresty
         tcp = ngx.socket.tcp
     else

--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -1,15 +1,5 @@
 -- Implementation of CQL Binary protocol V2 available at https://git-wip-us.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=doc/native_protocol_v2.spec;hb=HEAD
 
-local tcp
-if ngx then
-    -- openresty
-    tcp = ngx.socket.tcp
-else
-    -- fallback to luasocket
-    local socket = require("socket")
-    tcp = socket.tcp
-end
-
 local _M = {}
 
 _M.version = "0.0.1"
@@ -133,6 +123,16 @@ end
 
 function _M.new(self)
     math.randomseed(ngx and ngx.time() or os.time())
+
+    local tcp
+    if ngx then
+        -- openresty
+        tcp = ngx.socket.tcp
+    else
+        -- fallback to luasocket
+        tcp = require("socket").tcp
+    end
+
     local sock, err = tcp()
     if not sock then
         return nil, err


### PR DESCRIPTION
Here is a use case:

When nginx is starting, I want to prepare a few statements. If any statement fails preparation, the program will immediately stop (the user probably hasn't migrated his database or something).

This currently has to happen in the `init_by_lua` property of the configuration. However, this method does not have access to the Cosocket API. Thus, `ngx` is actually defined, but the `ngx.socket.tcp` access fails.

One solution to this problem would have been to just check:

```lua
if ngx and ngx.socket and ngx.socket.tcp then
```

Which would have allowed the preparation of statements in `init_by_lua`, but then the program would have been using luasocket during its entire execution.

So, the proposed solution is to check for the availability of the Cosocket API at each session creation. This way, the statements will be prepared using luasocket in the `init_by_lua`, and once the program has started, a new Cassandra session takes over, and will use the Cosocket API.

What do you think of this change? If you consider it wrong, let me know, if you think it needs more work, let me know too.