### PR TITLE
Fallback on luasocket if the initialization happens in the init phase

### DIFF
--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -130,7 +130,7 @@ function _M.new(self)
         tcp = ngx.socket.tcp
     else
         -- fallback to luasocket
-        -- It's also a fallback for openresty in, the
+        -- It's also a fallback for openresty in the
         -- "init" phase that doesn't support sockets
         tcp = require("socket").tcp
     end

--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -125,11 +125,13 @@ function _M.new(self)
     math.randomseed(ngx and ngx.time() or os.time())
 
     local tcp
-    if ngx and ngx.socket and ngx.socket.tcp then
+    if ngx and ngx.get_phase() ~= "init" then
         -- openresty
         tcp = ngx.socket.tcp
     else
         -- fallback to luasocket
+        -- It's also a fallback for openresty in, the
+        -- "init" phase that doesn't support sockets
         tcp = require("socket").tcp
     end
 

--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -131,7 +131,7 @@ function _M.new(self)
     else
         -- fallback to luasocket
         -- It's also a fallback for openresty in the
-        -- "init" phase that doesn't support sockets
+        -- "init" phase that doesn't support Cosockets
         tcp = require("socket").tcp
     end
 


### PR DESCRIPTION
Fallback on luasocket if the initialization happens in the `init` phase of openresty.

Because the `init` phase of openresty doesn't provided access to the Cosocket API, a fallback to luasocket is required. This is a fix to what @thibaultCha tried to achieve with #29.

