### PR TITLE
Only seed randomseed once

### DIFF
--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -7,6 +7,8 @@ local constants = require("constants")
 
 local CQL_VERSION = "3.0.0"
 
+math.randomseed(ngx and ngx.time() or os.time())
+
 local _M = {
   version="0.5-snapshot",
   consistency=constants.consistency,
@@ -29,8 +31,6 @@ _M.null = {type="null", value=nil}
 local mt = {__index=_M}
 
 function _M.new(self)
-  math.randomseed(ngx and ngx.time() or os.time())
-
   local tcp
   if ngx and ngx.get_phase ~= nil and ngx.get_phase() ~= "init" then
     -- openresty


### PR DESCRIPTION
Sooo... I stumbled against a real weird problem that took me a while to figure out. For developing Kong, we used to use only 1 socket (1 cassandra session) to make all our queries to Cassandra. Now that we are approaching a release, I wanted to do it the right way.

The right way, I believe (correct me if I'm wrong here please), is to create a new session on each query execution, and once the query is done, putting it back into the socket pool. So [this method](https://github.com/Mashape/kong/blob/master/src/kong/dao/cassandra/base_dao.lua#L198) needs to stop using the shared session (`self._db`) and perform as follow:

```lua
local session = cassandra.new()
session:set_timeout(self._properties.timeout)

local connected, err = session:connect(self._properties.hosts, self._properties.port)
if not connected then
  return nil, err
end
  
-- that is the part I really don't like, I feel like it's a waste of ressources to have to do this every time :/
local ok, err = session:set_keyspace(self._properties.keyspace)
if not ok then
  return nil, err
end

local results, err = session:execute(statement, values_to_bind, options)
if err then
  return nil, err
end

-- and finally, the interesting part
session:setkeepalive()
```

Can you confirm this is the right way instead of the current shared session?

If so, I then stumbled into this issue: we generate uuid for each inserted entity. Because we want to keep those uuids in memory, we have to create them from Lua, for this we use the `uuid` module. 

But if you run this script, calling `cassandra.new()` messes up with the uuid seeding:

```lua
local uuid = require "uuid"
local cassandra = require "cassandra"

uuid.seed()

-- Here, every generated uuid will be unique, fine
for i = 1, 3 do
  print(uuid())
end

print("")

-- Here, every generated uuid will be the same, because .new() sets the seed back to the current second :O
for i = 1, 3 do
  local session = cassandra.new()
  print(uuid())
end

print("")

-- Here, it's fine because I believe uuid.seed() will recreate the seed using luasocket which will use milliseconds.
-- I am not sure about that but I believe it is what happens.
for i = 1, 3 do
  local session = cassandra.new()
  uuid.seed()
  print(uuid())
end
```

So this PR fixes creating multiple sessions per second. In any case, I think it is better to seed the random generator only once during the lifetime of a program.