### PR TITLE
Feature: bump.sh, a little script to bump the version

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <new>"
+  exit 1
+fi
+
+pat="[0-9]*\.[0-9]*-[0-9]*"
+if [[ $1 =~ $pat ]]; then
+  echo Bumping to: $1
+  sed -i '' -e s/$pat/$1/g src/cassandra.lua
+  sed -i '' -e s/$pat/$1/g cassandra*.rockspec
+  mv cassandra*.rockspec cassandra-$1.rockspec
+
+  badge_version="${1/-/--}"
+  sed -i '' -e s/version-[0-9]*\.[0-9]*--[0-9]*/version-$badge_version/g README.md
+else
+  echo Invalid version: $1
+  exit 1
+fi


### PR DESCRIPTION
This is just a little script to bump the version everywhere as needed.

Not sure about this, you might keep it manually but I think it'll avoid forgetting something one day. Every bump needs to be carefully checked, of course! I did not add the `git tag` part neither the luarocks push for now. Not sure about it either.

```
./bump.sh 0.5-4
```