### PR TITLE
Fix: auto_paging return latest fetched set of rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased][unreleased]
 #### Added
 #### Fixed
+- `auto_pagination` option not returning the latest page in most cases
 
 ## [0.5-3] - 2015/03/01
 #### Fixed


### PR DESCRIPTION
"Test the limits!" they said... Well, sorry, I should have :grin: 

If the fetched rows was the latest page, because the paging_state flag was nil, the iteration used to stop and thus, not run the loop for the latest page of rows.

This fix allows the loop to run one last time to expose the very last page before actually stopping the iteration.