### PR TITLE
[fix] accessing nil rows in auto_paging. Fix #50

### DIFF
--- a/spec/functional_spec.lua
+++ b/spec/functional_spec.lua
@@ -427,6 +427,20 @@ describe("cassandra", function()
 
         assert.same(1, page_tracker)
       end)
+
+      it("should return valid parameters if no results found", function()
+        -- No results ~= no rows. This test validates the behaviour of err being
+        -- returned if no results are returned (most likely because of an invalid query)
+        local page_tracker = 0
+        for _, rows, page, err in session:execute("SELECT * FROM pagination_test_table WHERE id = 500", nil, {auto_paging=true}) do
+          assert.truthy(err) -- id is not a valid column
+          page_tracker = page_tracker + 1
+        end
+
+        -- Assert the loop has been run once.
+        assert.same(1, page_tracker)
+      end)
+
     end)
   end)
 

--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -216,9 +216,14 @@ function _M:execute(query, args, options)
       })
       page = page + 1
 
-      -- Allow the iterator to return the latest fetched rows
-      local paging_state = rows.meta.paging_state
-      if paging_state == nil and #rows > 0 then
+      -- If we have some results, retrieve the paging_state
+      local paging_state
+      if rows ~= nil then
+        paging_state = rows.meta.paging_state
+      end
+
+      -- Allow the iterator to return the latest page of rows or an error
+      if err or (paging_state == nil and rows and #rows > 0) then
         paging_state = false
       end
 


### PR DESCRIPTION
Proposed fix for #50

- `auto_paging` now doesn't try to access `rows` if no results are returned (different than 0 rows, no results is most likely because of an invalid query)
- If such an error happen, it will be returned in the loop (instead of erroring in `cassandra.lua`)