### PR TITLE
[feature] implement contact_point-specific port

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Connects to a single or multiple hosts at the given port.
 > **Parameters:**
 >
 > * `contact_points`: A string or an array of strings (hosts) to connect to.
-> * `port`: The port number
+>   * **Note:** If you wish to give a different port to one of those hosts, format the string as: "host:port" for that specific contact point. The specified `port` value will overwrite the `port` argument of `connect` for that contact point.
+> * `port`: The port number. **Default:** `9042`.
 
 > **Return values:**
 >

--- a/spec/functional_spec.lua
+++ b/spec/functional_spec.lua
@@ -62,6 +62,15 @@ describe("cassandra", function()
       assert.truthy(connected)
     end)
 
+    it("should be possible to send a list of hosts with ports for connection", function()
+      -- If a contact point is of form "host:port", this port will overwrite the one given as parameter of `connect`
+      local new_session = cassandra.new()
+      new_session:set_timeout(1000)
+      local connected, err = new_session:connect({"127.0.0.1:9042"}, 9999)
+      assert.falsy(err)
+      assert.truthy(connected)
+    end)
+
     it("should try another host if it fails to connect", function()
       local new_session = cassandra.new()
       new_session:set_timeout(1000)

--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -74,6 +74,12 @@ local function startup(self)
   return true
 end
 
+local function split(str)
+  local fields = {}
+  str:gsub("([^:]+)", function(c) fields[#fields+1] = c end)
+  return fields[1], fields[2]
+end
+
 function _M:connect(contact_points, port)
   if port == nil then port = 9042 end
   if contact_points == nil then
@@ -91,8 +97,14 @@ function _M:connect(contact_points, port)
     return nil, "session does not have a socket, create a new session first."
   end
   local ok, err
-  for _, host in ipairs(contact_points) do
-    ok, err = sock:connect(host, port)
+  for _, contact_point in ipairs(contact_points) do
+    -- Extract port if string is of the form "host:port"
+    local host, host_port = split(contact_point)
+    -- Default port is the one given as parameter
+    if not host_port then
+      host_port = port
+    end
+    ok, err = sock:connect(host, host_port)
     if ok then
       self.host = host
       break

--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -74,7 +74,7 @@ local function startup(self)
   return true
 end
 
-local function split(str)
+local function split_by_port(str)
   local fields = {}
   str:gsub("([^:]+)", function(c) fields[#fields+1] = c end)
   return fields[1], fields[2]
@@ -99,7 +99,7 @@ function _M:connect(contact_points, port)
   local ok, err
   for _, contact_point in ipairs(contact_points) do
     -- Extract port if string is of the form "host:port"
-    local host, host_port = split(contact_point)
+    local host, host_port = split_by_port(contact_point)
     -- Default port is the one given as parameter
     if not host_port then
       host_port = port


### PR DESCRIPTION
A very simple implementation of what is described in #55. Implemented in a way that doesn't introduce breaking changes.

Since the actual code accepts a string or an array of strings for hosts, I decided the most logic implementation was not to accept an array of tables `{host="x.x.x.x",port=xxxx}` but rather stick with an array of strings and optionally format some of those strings as `"host:port"`.

Thus, one might override the `port` argument of `connect` for one of the hosts if he or she specifies the host as `"host:port"`.

###### Example:

```lua
-- Here 192.168.0.0 will be on port 9999, while 127.0.0.1 will be on port 9042.
local connected, err = new_session:connect({"192.168.0.0", "127.0.0.1:9042"}, 9999) 
```