### PR TITLE
[fix] switching to uppercase keyspace

### DIFF
--- a/src/cassandra.lua
+++ b/src/cassandra.lua
@@ -259,7 +259,7 @@ function _M:execute(query, args, options)
 end
 
 function _M:set_keyspace(keyspace_name)
-  return self:execute("USE " .. keyspace_name)
+  return self:execute(string.format("USE \"%s\"", keyspace_name))
 end
 
 function _M:get_trace(result)


### PR DESCRIPTION
Apparently CQL prefers having the name of the keyspace in case it
contains any uppercase or funny characters such as: "Wiley_Booth", which
makes CQL believes we are asking for "wiley_booth" if quotes are not
included.